### PR TITLE
Fix remote code execution #1

### DIFF
--- a/Respaldo Server/borrar.php
+++ b/Respaldo Server/borrar.php
@@ -1,5 +1,5 @@
 <?php
-$var1 = $_POST['borrado'];
+$var1 = escapeshellarg($_POST['borrado']);
 shell_exec('rm '. $var1);
 $output1 = shell_exec(ls);
 echo "<pre>$output1</pre>";


### PR DESCRIPTION
Unsanitized user input being used in shell_exec leads to remote code execution.

Basically, I could submit a POST request with the `borrado` variable set like `borrado=;id` to execute the `id` command, and suchlike.

Always, always, sanitize user inputs.
